### PR TITLE
Persist scheduled visits to Firestore

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -47,3 +47,13 @@ export interface Interest {
   status: 'pendiente' | 'contactado';
   createdAt: Timestamp;
 }
+
+export interface ScheduledVisit {
+  visitId: string;
+  propertyId: string;
+  userUid: string;
+  propertyTitle: string;
+  date: Timestamp;
+  time: string;
+  createdAt: Timestamp;
+}


### PR DESCRIPTION
## Summary
- add `ScheduledVisit` type
- support saving, fetching and deleting scheduled visits in Firestore
- store confirmed visits in Firestore with localStorage fallback
- read visit info from Firestore when available
- remove visit record from Firestore when cancelled

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run typecheck` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685712493f5c832d837d8249aec1986c