### PR TITLE
Add autoprefixer to PostCSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@types/react-dom": "^18",
     "genkit-cli": "^1.8.0",
     "postcss": "^8",
+    "autoprefixer": "^10.4.20",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
   }

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,8 +1,12 @@
+import tailwindcss from 'tailwindcss';
+import peers from 'tailwindcss/peers/index.js';
+
 /** @type {import('postcss-load-config').Config} */
 const config = {
-  plugins: {
-    tailwindcss: {},
-  },
+  plugins: [
+    tailwindcss,
+    peers.lazyAutoprefixer(),
+  ],
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- enable autoprefixer via `tailwindcss` peers in PostCSS config
- declare autoprefixer as dev dependency

## Testing
- `npx tailwindcss -i src/app/globals.css -o /tmp/out.css --postcss`

------
https://chatgpt.com/codex/tasks/task_e_68571245e69c832d91970d56e52eb657